### PR TITLE
Ensure Ingress compatibility between Kubernetes versions in Helm chart

### DIFF
--- a/helm/doh-server/templates/_helpers.tpl
+++ b/helm/doh-server/templates/_helpers.tpl
@@ -30,3 +30,13 @@ Create chart name and version as used by the chart label.
 {{- define "doh-server.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "doh-server.ingress.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1" -}}
+{{- end }}
+{{- end -}}

--- a/helm/doh-server/templates/ingress.yaml
+++ b/helm/doh-server/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "doh-server.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ include "doh-server.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -20,6 +20,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  ingressClassName: {{ .Values.ingress.className }}
   tls:
     - hosts:
         - "{{ .Values.ingress.domainName }}"
@@ -29,7 +30,17 @@ spec:
       http:
         paths:
           - path: /dns-query
+            {{- if eq (include "doh-server.ingress.apiVersion" $) "networking.k8s.io/v1" }}
+            pathType: {{ .Values.ingress.pathType }}
+            {{- end }}
             backend:
+              {{- if eq (include "doh-server.ingress.apiVersion" $) "networking.k8s.io/v1" }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
+              {{- else }}
               serviceName: {{ $fullName }}
               servicePort: http
+              {{- end }}
 {{- end -}}

--- a/helm/doh-server/values.yaml
+++ b/helm/doh-server/values.yaml
@@ -27,10 +27,12 @@ service:
 
 ingress:
   enabled: false
+  className: nginx
   domainName: "doh.your-domain.com"
   annotations:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  pathType: Prefix
 
 resources:
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
Render the ingress based on apiVersion:

* extensions/v1beta1 (from 1.12? to 1.14)
* networking.k8s.io/v1beta1 (1.14 to 1.19)
* networking.k8s.io/v1 (1.19+)

*networking.k8s.io/v1* introduced a few changes that are managed by this commit (
`ingressClassName`, `PathType`, new `service.backend` syntax; cf
cf https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122)
*networking.k8s.io/v1* should be stable for a long time so the current
implementation should support all versions above 1.12.