### PR TITLE
Set container port to 8053 by default in Helm chart

### DIFF
--- a/helm/doh-server/templates/deployment.yaml
+++ b/helm/doh-server/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
             {{- end }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: {{ .Values.containerPort }}
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/helm/doh-server/values.yaml
+++ b/helm/doh-server/values.yaml
@@ -16,10 +16,12 @@ env:
   DEBUG: "0"
   UPSTREAM_DNS_SERVER: "udp:8.8.8.8:53"
   DOH_HTTP_PREFIX: "/dns-query"
-  DOH_SERVER_LISTEN: ":80"
+  DOH_SERVER_LISTEN: ":8053"
   DOH_SERVER_TIMEOUT: "10"
   DOH_SERVER_TRIES: "3"
   DOH_SERVER_VERBOSE: "false"
+
+containerPort: 8053
 
 service:
   type: ClusterIP


### PR DESCRIPTION
When starting the container, I get a permission denied on port 80. Since https://github.com/satishweb/docker-doh/pull/3, the container start as *nobody* and can't bind to the priveldged port 80 (all ports below 1024).                                                                  
                                                                                                       
This PR allows to set `containerPort` via values and set the default port to *8053* in                 
both *env.DOH_SERVER_LISTEN* and *containerPort* so the container can start. Changing the listening port require to update these two settings.