### PR TITLE
Allowing to set deployment and service annotations in Helm chart

### DIFF
--- a/helm/doh-server/templates/deployment.yaml
+++ b/helm/doh-server/templates/deployment.yaml
@@ -8,6 +8,10 @@ metadata:
     helm.sh/chart: {{ include "doh-server.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- if .Values.deploymentAnnotations }}
+  annotations:
+{{ toYaml .Values.deploymentAnnotations | indent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/helm/doh-server/templates/service.yaml
+++ b/helm/doh-server/templates/service.yaml
@@ -7,6 +7,10 @@ metadata:
     helm.sh/chart: {{ include "doh-server.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/helm/doh-server/values.yaml
+++ b/helm/doh-server/values.yaml
@@ -24,6 +24,7 @@ env:
 service:
   type: ClusterIP
   port: 80
+  annotations:
 
 ingress:
   enabled: false


### PR DESCRIPTION
I finally put the annotations I required for external-dns in the ingress (which was already implemented) so I don't personally need this.