### PR TITLE
Allowing to set probes query in Helm chart

### DIFF
--- a/helm/doh-server/templates/deployment.yaml
+++ b/helm/doh-server/templates/deployment.yaml
@@ -35,11 +35,11 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /dns-query?name=google.com
+              path: /dns-query?{{ .Values.probesQuery }}
               port: http
           readinessProbe:
             httpGet:
-              path: /dns-query?name=google.com
+              path: /dns-query?{{ .Values.probesQuery }}
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/helm/doh-server/values.yaml
+++ b/helm/doh-server/values.yaml
@@ -44,6 +44,8 @@ resources:
      cpu: 100m
      memory: 128Mi
 
+probesQuery: name=google.com
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
Set the dns-query query for liveness and readiness probes.

Default still to *name=google.com*